### PR TITLE
Updated link for compatibility with docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,9 +27,7 @@ Getting Started
 ===============
 
 - `Tutorial notebooks <https://nbviewer.jupyter.org/github/prmiles/pyfod/tree/master/tutorials/index.ipynb>`_
-- `Release history`_
-
-.. _Release history: CHANGELOG.rst
+- `Release history <https://github.com/prmiles/pyfod/blob/master/CHANGELOG.rst>`_
 
 Feedback
 ========


### PR DESCRIPTION
Previous release history link only worked from GitHub, not on readthedocs.